### PR TITLE
feat: improve Standard.kt

### DIFF
--- a/lib/src/main/kotlin/net/llvg/utilities/Standard.kt
+++ b/lib/src/main/kotlin/net/llvg/utilities/Standard.kt
@@ -1,8 +1,88 @@
 package net.llvg.utilities
 
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.internal.InlineOnly
 
 @InlineOnly
 public inline fun loop(action: () -> Unit): Nothing {
     while (true) action()
+}
+
+@InlineOnly
+public inline fun Any?.isNull(): Boolean {
+    contract {
+        returns(true) implies (this@isNull === null)
+        returns(false) implies (this@isNull !== null)
+    }
+    
+    return this === null
+}
+
+@InlineOnly
+public inline fun <R> Any?.onNull(action: () -> R): R? {
+    contract {
+        callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+    }
+    
+    return if (isNull()) action() else null
+}
+
+@InlineOnly
+public inline fun Any?.notNull(): Boolean {
+    contract {
+        returns(true) implies (this@notNull !== null)
+        returns(false) implies (this@notNull === null)
+    }
+    
+    return !isNull()
+}
+
+@InlineOnly
+public inline fun Any?.invNull(): Unit? {
+    contract {
+        returnsNotNull() implies (this@invNull === null)
+        returns(null) implies (this@invNull !== null)
+    }
+    
+    return if (isNull()) Unit else null
+}
+
+@InlineOnly
+public inline fun <T : Any> T?.mapNull(action: () -> T): T {
+    contract {
+        callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+    }
+    
+    return if (isNull()) action() else this
+}
+
+@InlineOnly
+@Suppress("UnusedReceiverParameter")
+public inline fun <R> Any?.then(action: () -> R): R {
+    contract {
+        callsInPlace(action, InvocationKind.EXACTLY_ONCE)
+    }
+    
+    return action()
+}
+
+@InlineOnly
+public inline fun Boolean.takeT(): Boolean? {
+    contract {
+        returnsNotNull() implies this@takeT
+        returns(null) implies !this@takeT
+    }
+    
+    return if (this) true else null
+}
+
+@InlineOnly
+public inline fun Boolean.takeF(): Boolean? {
+    contract {
+        returnsNotNull() implies !this@takeF
+        returns(null) implies this@takeF
+    }
+    
+    return if (this) null else false
 }

--- a/lib/src/main/kotlin/net/llvg/utilities/Standard.kt
+++ b/lib/src/main/kotlin/net/llvg/utilities/Standard.kt
@@ -20,15 +20,6 @@ public inline fun Any?.isNull(): Boolean {
 }
 
 @InlineOnly
-public inline fun <R> Any?.onNull(action: () -> R): R? {
-    contract {
-        callsInPlace(action, InvocationKind.AT_MOST_ONCE)
-    }
-    
-    return if (isNull()) action() else null
-}
-
-@InlineOnly
 public inline fun Any?.notNull(): Boolean {
     contract {
         returns(true) implies (this@notNull !== null)
@@ -46,6 +37,15 @@ public inline fun Any?.invNull(): Unit? {
     }
     
     return if (isNull()) Unit else null
+}
+
+@InlineOnly
+public inline fun <R> Any?.onNull(action: () -> R): R? {
+    contract {
+        callsInPlace(action, InvocationKind.AT_MOST_ONCE)
+    }
+    
+    return if (isNull()) action() else null
 }
 
 @InlineOnly


### PR DESCRIPTION
# New Methods added to `Standard.kt`

### `Any?.isNull(): Boolean`
- Map `null` to `true`, otherwise `false`

### `Any?.notNull(): Boolean`
- Map `null` to `false`, otherwise `true`

> [!NOTE]
> This method is an inverse version of `Any.isNull(): Boolean`

### `Any?.invNull(): Unit?`
- Map `null` to `Unit`, otherwise `null` (Invert nullability but lose the reference infomation)

### `<R> Any?.onNull(action: ()->R): R`
- Map `null` to invokation result of `action`, otherwise `null`

### `<T : Any> T?.mapNull(action: ()->T): T`
- Map `null` to invokation result of `action`, otherwise the receiver object

### `<R> Any?.then(action: ()->R): R`
- Return invokation result of `action`

### `Boolean.takeT(): Boolean?`
- Map `false` to `null`, otherwise `true`

### `Boolean.takeF(): Boolean?`
- Map `true` to `null`, otherwise `false`

> [!NOTE]
> This method is an inverse version of `Boolean.takeT(): Boolean?`